### PR TITLE
Feature/compress signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/sirupsen/logrus v1.8.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sys v0.0.0-20210303074136-134d130e1a04 // indirect
+	vuvuzela.io/crypto v0.0.0-20190327123840-80a93a3ed1d6
 )

--- a/go.sum
+++ b/go.sum
@@ -645,3 +645,5 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
+vuvuzela.io/crypto v0.0.0-20190327123840-80a93a3ed1d6 h1:wHM6aJ7thxPU/rW0iG9mliciTOgVX8TSlcbINg0xHiQ=
+vuvuzela.io/crypto v0.0.0-20190327123840-80a93a3ed1d6/go.mod h1:K9x2j50IChF9KMDGvo2hv/RIDuQsHrv2pifiwH9jApk=

--- a/herumi/secret_key.go
+++ b/herumi/secret_key.go
@@ -2,7 +2,9 @@ package herumi
 
 import (
 	"fmt"
+	"io"
 	"os"
+	vbls "vuvuzela.io/crypto/bls"
 
 	bls12 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/pkg/errors"
@@ -12,6 +14,10 @@ import (
 // Bls12SecretKey used in the BLS signature scheme.
 type Bls12SecretKey struct {
 	p *bls12.SecretKey
+}
+
+func GenerateKey(rand io.Reader) (*vbls.PublicKey, *vbls.PrivateKey, error) {
+	return vbls.GenerateKey(rand)
 }
 
 // RandKey creates a new private key using a random method provided as an io.Reader.

--- a/herumi/secret_key_test.go
+++ b/herumi/secret_key_test.go
@@ -1,6 +1,7 @@
 package herumi_test
 
 import (
+	rand2 "crypto/rand"
 	"errors"
 	"testing"
 
@@ -11,6 +12,14 @@ import (
 	"github.com/silesiacoin/bls/testutil/assert"
 	"github.com/silesiacoin/bls/testutil/require"
 )
+
+func TestGenerateKey(t *testing.T) {
+	rand := rand2.Reader
+	public, private, err := herumi.GenerateKey(rand)
+	assert.NoError(t, err)
+	assert.NotNil(t, public)
+	assert.NotNil(t, private)
+}
 
 func TestMarshalUnmarshal(t *testing.T) {
 	priv, err := herumi.RandKey()

--- a/herumi/signature.go
+++ b/herumi/signature.go
@@ -19,6 +19,10 @@ type Signature struct {
 	s *bls12.Sign
 }
 
+func Sign(privateKey *vbls.PrivateKey, message []byte) vbls.Signature {
+	return vbls.Sign(privateKey, message)
+}
+
 // SignatureFromBytes creates a BLS signature from a LittleEndian byte slice.
 func SignatureFromBytes(sig []byte) (common.Signature, error) {
 	if "true" == os.Getenv("SKIP_BLS_VERIFY") {

--- a/herumi/signature_test.go
+++ b/herumi/signature_test.go
@@ -1,8 +1,10 @@
 package herumi
 
 import (
+	"crypto/rand"
 	"errors"
 	"testing"
+	vbls "vuvuzela.io/crypto/bls"
 
 	bls12 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/silesiacoin/bls/common"
@@ -17,6 +19,23 @@ func TestSignVerify(t *testing.T) {
 	msg := []byte("hello")
 	sig := priv.Sign(msg)
 	assert.DeepEqual(t, true, sig.Verify(pub, msg))
+}
+
+func TestCompressSignVerify(t *testing.T) {
+	random := rand.Reader
+	pub, priv, err := GenerateKey(random)
+	assert.NoError(t, err)
+	assert.NotNil(t, priv)
+	assert.NotNil(t, pub)
+	msg := []byte{'h', 'e', 'l', 'l', 'o'}
+	signature := vbls.Sign(priv, msg)
+	compressedSignature := signature.Compress()
+	pubKeys := make([]*vbls.PublicKey, 0)
+	pubKeys = append(pubKeys, pub)
+	messages := make([][]byte, 0)
+	messages = append(messages, msg)
+	valid := VerifyCompressed(pubKeys, messages, compressedSignature)
+	assert.Equal(t, true, valid)
 }
 
 func TestAggregateVerify(t *testing.T) {

--- a/herumi/signature_test.go
+++ b/herumi/signature_test.go
@@ -28,7 +28,7 @@ func TestCompressSignVerify(t *testing.T) {
 	assert.NotNil(t, priv)
 	assert.NotNil(t, pub)
 	msg := []byte{'h', 'e', 'l', 'l', 'o'}
-	signature := vbls.Sign(priv, msg)
+	signature := Sign(priv, msg)
 	compressedSignature := signature.Compress()
 	pubKeys := make([]*vbls.PublicKey, 0)
 	pubKeys = append(pubKeys, pub)


### PR DESCRIPTION
I need compression to 32 bytes in signature. This pull request allows it.
TODO: consider removing all herumi package or moving this changes into separate package